### PR TITLE
added support for new leia --timeout option

### DIFF
--- a/.github/workflows/pr-files-tests.yml
+++ b/.github/workflows/pr-files-tests.yml
@@ -49,3 +49,4 @@ jobs:
           test-header: Seal
           cleanup-header: Deliver
           debug: true
+          timeout: 100

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -30,4 +30,3 @@ jobs:
           stdin: true
           test-header: Test,Validat,Verif,Testing 1 2 3
           version: "^0.6.5"
-          timeout: 100

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -30,3 +30,4 @@ jobs:
           stdin: true
           test-header: Test,Validat,Verif,Testing 1 2 3
           version: "^0.6.5"
+          timeout: 100

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -26,7 +26,7 @@ jobs:
           debug: true
           cleanup-header: Clean,Tear,Burn,Destroy
           retry: 0
-          setup-header: Start,Setup,This is the dawning,So it begins!
+          setup-header: "Start,Setup,This is the dawning,So it begins!"
           stdin: true
           test-header: Test,Validat,Verif,Testing 1 2 3
           version: "^0.6.5"

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -26,7 +26,7 @@ jobs:
           debug: true
           cleanup-header: Clean,Tear,Burn,Destroy
           retry: 0
-          setup-header: "Start,Setup,This is the dawning,So it begins!"
+          setup-header: Start,Setup,This is the dawning,So it begins!
           stdin: true
           test-header: Test,Validat,Verif,Testing 1 2 3
           version: "^0.6.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added support for new `leia` `--timeout` option
+
 ## v2.2.1 - [July 22, 2024](https://github.com/lando/run-leia-action/releases/tag/v2.2.1)
 
 * Fixed bug causing `stdin: true` to blow away the `shell` selection

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ These keys are set to sane defaults but can be modified as needed.
 | `shell` | The shell to use. | `auto` | `bash` |
 | `stdin` | Attach stdin when the tests are run. | `false` | `true` |
 | `test-header` | The test headers to parse. | `Test,Validat,Verif` | `Testing 1 2 3` |
+| `timeout` | The amount of time for the test to run before a timeout, in seconds. | `1800` | `7` |
 | `version` | The fallback global version of Leia to install if no local version is detected. | `latest` | `0.6.5` |
 
 > **NOTE:** Please read Leia's [shell considerations](https://github.com/lando/leia#shell-considerations) for details on how `shell: auto` works.
@@ -55,6 +56,7 @@ These keys are set to sane defaults but can be modified as needed.
     shell: bash
     stdin: true
     test-header: Test
+    timeout: 5
     version: "^0.6.5"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "The test headers to parse."
     required: false
     default: "Test,Validat,Verif"
+  timeout:
+    description: "The amount of time for the test to run before a timeout, in seconds."
+    required: false
+    default: 1800
   version:
     description: "The fallback global version of Leia to install if no local version is detected."
     required: false
@@ -120,11 +124,12 @@ runs:
         echo "::group::Leia information"
           echo "bin: $(which leia)"
           echo "version: $(leia --version)"
-          echo "command: leia ${{ inputs.leia-test }} --setup-header=\"${{ inputs.setup-header }}\" --test-header=\"${{ inputs.test-header }}\" --cleanup-header=\"${{ inputs.cleanup-header }}\" --retry=${{ inputs.retry }} $OPTS"
+          echo "command: leia ${{ inputs.leia-test }} --cleanup-header=\"${{ inputs.cleanup-header }}\" --retry=${{ inputs.retry }} --setup-header=\"${{ inputs.setup-header }}\" --test-header=\"${{ inputs.test-header }}\" --timeout=\"${{ inputs.timeout }}\" $OPTS"
         echo "::endgroup::"
 
         leia ${{ inputs.leia-test }} \
-          --setup-header="${{ inputs.setup-header }}" \
-          --test-header="${{ inputs.test-header }}" \
           --cleanup-header="${{ inputs.cleanup-header }}" \
-          --retry=${{ inputs.retry }} $OPTS
+          --retry=${{ inputs.retry }} $OPTS \
+          --setup-header="${{ inputs.setup-header }}" \
+          --timeout="${{ inputs.timeout }}" \
+          --test-header="${{ inputs.test-header }}"

--- a/action.yml
+++ b/action.yml
@@ -128,8 +128,8 @@ runs:
         echo "::endgroup::"
 
         leia ${{ inputs.leia-test }} \
-          --cleanup-header="${{ inputs.cleanup-header }}" \
-          --retry=${{ inputs.retry }} \
           --setup-header="${{ inputs.setup-header }}" \
+          --test-header="${{ inputs.test-header }}" \
+          --cleanup-header="${{ inputs.cleanup-header }}" \
           --timeout="${{ inputs.timeout }}" \
-          --test-header="${{ inputs.test-header }}" $OPTS
+          --retry=${{ inputs.retry }} $OPTS

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
 
         leia ${{ inputs.leia-test }} \
           --cleanup-header="${{ inputs.cleanup-header }}" \
-          --retry=${{ inputs.retry }} $OPTS \
+          --retry=${{ inputs.retry }} \
           --setup-header="${{ inputs.setup-header }}" \
           --timeout="${{ inputs.timeout }}" \
-          --test-header="${{ inputs.test-header }}"
+          --test-header="${{ inputs.test-header }}" $OPTS


### PR DESCRIPTION
### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)
- [ ] I've updated this PR with the latest code from `main`
- [ ] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
