### PR TITLE
Add Bun runtime support

### DIFF
--- a/.github/workflows/label-add-to-project.yml
+++ b/.github/workflows/label-add-to-project.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         flag:
           - flag
 

--- a/.github/workflows/pr-files-tests.yml
+++ b/.github/workflows/pr-files-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         leia-test:
           - tests/TEST1.md
           - tests/TEST2.md

--- a/.github/workflows/pr-lagoon-mode-tests.yml
+++ b/.github/workflows/pr-lagoon-mode-tests.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
           - macos-14
-          - ubuntu-22.04
+          - macos-15
+          - ubuntu-24.04
           - windows-2022
         leia-test:
           - tests/TEST1.md

--- a/.github/workflows/pr-local-test.yml
+++ b/.github/workflows/pr-local-test.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15
           - macos-14
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
         node-version:
           - '18'

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -12,9 +12,22 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
-        leia-test:
-          - ./tests/TEST4.md
+          - ubuntu-24.04
+        with:
+          - leia-test: ./tests/TEST4.md
+            debug: true
+            cleanup-header: Clean,Tear,Burn,Destroy
+            retry: 0
+            setup-header: "Start,Setup,This is the dawning,So it begins!"
+            stdin: true
+            test-header: Test,Validat,Verif,Testing 1 2 3
+            version: "^0.6.5"
+          - leia-test: ./tests/TEST1.md
+            runtime: node
+          - leia-test: ./tests/TEST8.md
+            runtime: bun
+            bun-version: "1.3.5"
+
 
     steps:
       - name: Checkout action code
@@ -22,11 +35,4 @@ jobs:
       - name: Run Leia Action
         uses: ./
         with:
-          leia-test: ${{ matrix.leia-test }}
-          debug: true
-          cleanup-header: Clean,Tear,Burn,Destroy
-          retry: 0
-          setup-header: "Start,Setup,This is the dawning,So it begins!"
-          stdin: true
-          test-header: Test,Validat,Verif,Testing 1 2 3
-          version: "^0.6.5"
+          ${{ matrix.with }}

--- a/.github/workflows/pr-os-tests.yml
+++ b/.github/workflows/pr-os-tests.yml
@@ -12,11 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
           - macos-14
-          - ubuntu-22.04
+          - macos-15
+          - ubuntu-24.04
           - windows-2022
-
     steps:
       - name: Checkout action code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-shells-test.yml
+++ b/.github/workflows/pr-shells-test.yml
@@ -12,26 +12,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             shell: auto
             leia-test: ./tests/TEST5.md
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             shell: bash
             leia-test: ./tests/TEST5.md
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             shell: sh
             leia-test: ./tests/TEST5.md
 
-          - os: macos-13
+          - os: macos-15
             shell: auto
             leia-test: ./tests/TEST5.md
-          - os: macos-13
+          - os: macos-15
             shell: bash
             leia-test: ./tests/TEST5.md
-          - os: macos-13
+          - os: macos-15
             shell: zsh
             leia-test: ./tests/TEST5.md
-          - os: macos-13
+          - os: macos-15
             shell: sh
             leia-test: ./tests/TEST5.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added support for `runtime` input to select between `node` and `bun` runtimes
+* Added support for `bun-version` input to specify the version of Bun to use
+
 ## v2.3.0 - [July 22, 2024](https://github.com/lando/run-leia-action/releases/tag/v2.3.0)
 
 * Added support for new `leia` `--timeout` option

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ These keys are set to sane defaults but can be modified as needed.
 | `test-header` | The test headers to parse. | `Test,Validat,Verif` | `Testing 1 2 3` |
 | `timeout` | The amount of time for the test to run before a timeout, in seconds. | `1800` | `7` |
 | `version` | The fallback global version of Leia to install if no local version is detected. | `latest` | `0.6.5` |
+| `runtime` | Runtime to use for running leia. | `node` | `bun` |
+| `bun-version` | The version of Bun to use when runtime is bun. | `latest` | `1.3.5` |
 
 > **NOTE:** Please read Leia's [shell considerations](https://github.com/lando/leia#shell-considerations) for details on how `shell: auto` works.
 
@@ -58,6 +60,17 @@ These keys are set to sane defaults but can be modified as needed.
     test-header: Test
     timeout: 5
     version: "^0.6.5"
+```
+
+**Using Bun runtime:**
+
+```yaml
+- name: Run Leia Tests
+  uses: lando/run-leia-action@v2
+  with:
+    leia-test: tests/leia-test-1.md
+    runtime: bun
+    bun-version: latest
 ```
 
 ## Changelog

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,14 @@ inputs:
     description: "The fallback global version of Leia to install if no local version is detected."
     required: false
     default: "latest"
+  runtime:
+    description: "Runtime to use: node or bun"
+    required: false
+    default: "node"
+  bun-version:
+    description: "The version of Bun to use when runtime is bun."
+    required: false
+    default: "latest"
 
 runs:
   using: composite
@@ -68,14 +76,17 @@ runs:
         fi
 
     - name: Install node
+      if: inputs.runtime != 'bun'
       uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: npm
     - name: Add local bin to PATH
+      if: inputs.runtime != 'bun'
       shell: bash
       run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> $GITHUB_PATH
     - name: Ensure Leia is installed
+      if: inputs.runtime != 'bun'
       shell: bash
       run: |
         if ! leia --version &>/dev/null; then
@@ -88,6 +99,11 @@ runs:
           echo "::error title=Cannot run leia::Cannot seem to find the Leia binary!"
           exit 11
         fi
+    - name: Install bun
+      if: inputs.runtime == 'bun'
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
     - name: Activate Lagoon Mode
       if: runner.os == 'Linux' && inputs.lagoon-mode == 'true'
       shell: bash
@@ -101,6 +117,13 @@ runs:
     - name: Run Leia tests
       shell: bash
       run: |
+        # SET LEIA COMMAND BASED ON RUNTIME
+        if [ "${{ inputs.runtime }}" == "bun" ]; then
+          LEIA_CMD="bunx @lando/leia@${{ inputs.version }}"
+        else
+          LEIA_CMD="leia"
+        fi
+
         # DO THE OPTS
         OPTS=
 
@@ -122,12 +145,17 @@ runs:
         fi
 
         echo "::group::Leia information"
-          echo "bin: $(which leia)"
-          echo "version: $(leia --version)"
-          echo "command: leia ${{ inputs.leia-test }} --cleanup-header=\"${{ inputs.cleanup-header }}\" --retry=${{ inputs.retry }} --setup-header=\"${{ inputs.setup-header }}\" --test-header=\"${{ inputs.test-header }}\" --timeout=\"${{ inputs.timeout }}\" $OPTS"
+          if [ "${{ inputs.runtime }}" == "bun" ]; then
+            echo "bin: $(which bun)"
+            echo "version: $(bun --version)"
+          else
+            echo "bin: $(which leia)"
+            echo "version: $(leia --version)"
+          fi
+          echo "command: $LEIA_CMD ${{ inputs.leia-test }} --cleanup-header=\"${{ inputs.cleanup-header }}\" --retry=${{ inputs.retry }} --setup-header=\"${{ inputs.setup-header }}\" --test-header=\"${{ inputs.test-header }}\" --timeout=\"${{ inputs.timeout }}\" $OPTS"
         echo "::endgroup::"
 
-        leia ${{ inputs.leia-test }} \
+        $LEIA_CMD ${{ inputs.leia-test }} \
           --setup-header="${{ inputs.setup-header }}" \
           --test-header="${{ inputs.test-header }}" \
           --cleanup-header="${{ inputs.cleanup-header }}" \

--- a/tests/TEST8.md
+++ b/tests/TEST8.md
@@ -1,0 +1,7 @@
+# Bun Runtime Test
+
+## Test that bun is available
+
+```bash
+bun --version
+```


### PR DESCRIPTION
## Summary

- Adds `runtime` input (`node` default, `bun` option) and `bun-version` input
- Uses `bunx @lando/leia` instead of global install when Bun is selected

## Problem

The current implementation crashes in Bun-based repos because `actions/setup-node` with `cache: npm` requires a `package-lock.json` to be present. Bun repos use `bun.lock` instead.

## Solution

When `runtime: bun` is specified, skip the Node setup entirely and use `oven-sh/setup-bun` + `bunx` to run leia directly.